### PR TITLE
Oubliette samples password file: Add ISO-8859-1 encoding

### DIFF
--- a/Oubliette_Password_Manager/README.md
+++ b/Oubliette_Password_Manager/README.md
@@ -2,7 +2,7 @@ Oubliette Password Manager - Sample files
 =========================================
 
 Hash creation example:
-
+```
     for f in *.oub ; do echo $f ; echo -n '  ' ; ./oubliette2john.py $f ; done
     oubliette-blowfish-12345678.oub
       $oubliette-blowfish$16c863009dbc7a89fa26520aeeae5543beda0bbf41622be472d7c7320c8ea66f
@@ -16,11 +16,11 @@ Hash creation example:
       $oubliette-idea$9c846ab8c1dc703330521e7ca77489beded5d23b3aa821edea8f0324fbdb9f08
     oubliette-idea-complex-withdata-v15.oub
       $oubliette-idea$9c846ab8c1dc703330521e7ca77489beded5d23b3aa821edea8f0324fbdb9f08
+```
+Testing the passwords:
+```
+    john -w:oubliette-passwords.txt *.hash
+```
+The complex test vector is originally made in ISO-8859-1 and thus `--target-encoding=iso-8859-1` would be needed. In order to avoid that, the hint file `oubliette-passwords.txt` now contains two versions of it, one in UTF-8 and one in ISO-8859-1, so that extra option is not needed.
 
-Testing the complex password requires target-enc set to iso-8859-1:
-
-    cat oubliette-passwords.txt >> run/password.lst
-    john -target-enc=iso-8859-1 oubliette-blowfish-complex.hash
-    john -target-enc=iso-8859-1 oubliette-blowfish-complex-withdata-v15.hash
-    john -target-enc=iso-8859-1 oubliette-idea-complex.hash
-    john -target-enc=iso-8859-1 oubliette-idea-complex-withdata-v15.hash
+See `docs/ENCODINGS` in the john tree for more information.

--- a/Oubliette_Password_Manager/oubliette-passwords.txt
+++ b/Oubliette_Password_Manager/oubliette-passwords.txt
@@ -1,2 +1,12 @@
+#!comment:
+#!comment: Warning: Editing this file may destroy its mixed encodings.
+#!comment:
 12345678
+#!comment:
+#!comment: The below is encoded in UTF-8 but the test vector is ISO-8859-1
+#!comment:
 Ã‘Â¢c^Â¬NJ%HÃ•EsÂ®ySÂ²Ã¥iÃ¼YÃŽ@!jgT\Ã¿\Ã¾zRÂ¾wÃ’wÂ¸a9EÃ°+>J<Â¤.SÃ˜ÂºqÃˆ2&i7/Ãº}Â¡Ã¿ÃŸÃ”Âº)MÃ”ri@Ãƒ\"+yP!A]Ã‡Ãj?Ã­&{4~Â¹!
+#!comment:
+#!comment: Here is the same password encoded as ISO-8859-1
+#!comment:
+Ñ¢c^¬NJ%HÕEs®yS²åiüYÎ@!jgT\ÿ\þzR¾wÒw¸a9Eð+>J<¤.SØºqÈ2&i7/ú}¡ÿßÔº)MÔri@Ã\"+yP!A]ÇÝj?í&{4~¹!


### PR DESCRIPTION
Also amends README.md, explaining this. As it had the .md extension, I edited it a little using Markup

Fixes #34